### PR TITLE
Configurable version of internally used polyglot-translate-plugin

### DIFF
--- a/org.jboss.tools.maven.polyglot.poc.core/src/main/java/org/jboss/tools/maven/polyglot/poc/internal/core/PolyglotPomChangeListener.java
+++ b/org.jboss.tools.maven.polyglot.poc.core/src/main/java/org/jboss/tools/maven/polyglot/poc/internal/core/PolyglotPomChangeListener.java
@@ -62,8 +62,9 @@ public class PolyglotPomChangeListener implements IResourceChangeListener {
 
   protected void requestPomTranslation(List<IFile> poms) {
     if(poms != null && !poms.isEmpty()) {
+      final String version = preferences.get(IPolyglotPreferenceConstants.POLYGLOT_TRANSLATION_PLUGIN_VERSION, "").trim();
       LOG.debug("Automatic update of {}", poms);
-      new PomTranslatorJob(MavenPlugin.getMavenProjectRegistry(), MavenPluginActivator.getDefault().getMavenMarkerManager(), poms).schedule();
+      new PomTranslatorJob(MavenPlugin.getMavenProjectRegistry(), MavenPluginActivator.getDefault().getMavenMarkerManager(), poms, version).schedule();
     }
   }
 }

--- a/org.jboss.tools.maven.polyglot.poc.core/src/main/java/org/jboss/tools/maven/polyglot/poc/internal/core/PomTranslatorJob.java
+++ b/org.jboss.tools.maven.polyglot.poc.core/src/main/java/org/jboss/tools/maven/polyglot/poc/internal/core/PomTranslatorJob.java
@@ -65,17 +65,20 @@ public class PomTranslatorJob extends Job {
 
   private IMavenMarkerManager markerManager;
 
+  final private String translatePluginVersion;
+
   
-  public PomTranslatorJob(List<IFile> poms) {
-	  this(MavenPlugin.getMavenProjectRegistry(), MavenPluginActivator.getDefault().getMavenMarkerManager(), poms);
+  public PomTranslatorJob(List<IFile> poms, String translatePluginVersion) {
+	  this(MavenPlugin.getMavenProjectRegistry(), MavenPluginActivator.getDefault().getMavenMarkerManager(), poms, translatePluginVersion);
   }
   
-  public PomTranslatorJob(IMavenProjectRegistry projectManager, IMavenMarkerManager markerManager, List<IFile> poms) {
+  public PomTranslatorJob(IMavenProjectRegistry projectManager, IMavenMarkerManager markerManager, List<IFile> poms, String translatePluginVersion) {
     super("Pom translator");
     Assert.isNotNull(poms);
     this.projectManager = projectManager;
     this.markerManager = markerManager;
     this.poms = new ArrayList<>(poms);
+    this.translatePluginVersion = translatePluginVersion;
   }
 
   @Override
@@ -140,7 +143,10 @@ public class PomTranslatorJob extends Job {
     final MavenExecutionRequest request = context.getExecutionRequest();
     File pomFile = pom.getRawLocation().toFile();
     request.setBaseDirectory(pomFile.getParentFile());
-    request.setGoals(Arrays.asList("io.takari.polyglot:polyglot-translate-plugin:translate"));
+	final String pluginTargetLine = "io.takari.polyglot:polyglot-translate-plugin" +
+			(translatePluginVersion.isEmpty() ? "" : ":" + translatePluginVersion) +
+			":translate";
+	request.setGoals(Arrays.asList(pluginTargetLine));
     request.setUpdateSnapshots(false);
     Properties props = new Properties();
     props.put("input", input.getRawLocation().toOSString());

--- a/org.jboss.tools.maven.polyglot.poc.core/src/main/java/org/jboss/tools/maven/polyglot/poc/internal/core/preferences/IPolyglotPreferenceConstants.java
+++ b/org.jboss.tools.maven.polyglot.poc.core/src/main/java/org/jboss/tools/maven/polyglot/poc/internal/core/preferences/IPolyglotPreferenceConstants.java
@@ -18,5 +18,7 @@ package org.jboss.tools.maven.polyglot.poc.internal.core.preferences;
 public interface IPolyglotPreferenceConstants {
 
 	String ENABLE_AUTOMATIC_POM_TRANSLATION = "polyglot.maven.autoPomTranslation";
+	
+	String POLYGLOT_TRANSLATION_PLUGIN_VERSION = "polyglot.maven.translationPluginVersion";
 
 }

--- a/org.jboss.tools.maven.polyglot.poc.core/src/main/java/org/jboss/tools/maven/polyglot/poc/internal/core/preferences/MavenPolyglotPreferenceInitializer.java
+++ b/org.jboss.tools.maven.polyglot.poc.core/src/main/java/org/jboss/tools/maven/polyglot/poc/internal/core/preferences/MavenPolyglotPreferenceInitializer.java
@@ -15,7 +15,6 @@ import org.eclipse.core.runtime.preferences.DefaultScope;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.jboss.tools.maven.polyglot.poc.internal.core.PolyglotSupportActivator;
 
-
 /**
  * Preferences initializer.
  * 
@@ -24,12 +23,13 @@ import org.jboss.tools.maven.polyglot.poc.internal.core.PolyglotSupportActivator
 public class MavenPolyglotPreferenceInitializer extends AbstractPreferenceInitializer {
 
 	/**
-	   * @see org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer#initializeDefaultPreferences()
-	   */
-	  @Override
-	  public void initializeDefaultPreferences() {
-	    IEclipsePreferences store = DefaultScope.INSTANCE.getNode(PolyglotSupportActivator.PLUGIN_ID);
-	    store.putBoolean(IPolyglotPreferenceConstants.ENABLE_AUTOMATIC_POM_TRANSLATION, true);
-	  }
+	 * @see org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer#initializeDefaultPreferences()
+	 */
+	@Override
+	public void initializeDefaultPreferences() {
+		final IEclipsePreferences store = DefaultScope.INSTANCE.getNode(PolyglotSupportActivator.PLUGIN_ID);
+		store.putBoolean(IPolyglotPreferenceConstants.ENABLE_AUTOMATIC_POM_TRANSLATION, true);
+		store.put(IPolyglotPreferenceConstants.POLYGLOT_TRANSLATION_PLUGIN_VERSION, "");
+	}
 
 }

--- a/org.jboss.tools.maven.polyglot.poc.ui/src/main/java/org/jboss/tools/maven/polyglot/poc/internal/ui/PolyglotSupportUIActivator.java
+++ b/org.jboss.tools.maven.polyglot.poc.ui/src/main/java/org/jboss/tools/maven/polyglot/poc/internal/ui/PolyglotSupportUIActivator.java
@@ -36,6 +36,7 @@ public class PolyglotSupportUIActivator extends Plugin implements IStartup {
 		super.start(context);
 		//forces activation of core plugin
 		getPreferenceStore().getBoolean(IPolyglotPreferenceConstants.ENABLE_AUTOMATIC_POM_TRANSLATION);
+		getPreferenceStore().getString(IPolyglotPreferenceConstants.POLYGLOT_TRANSLATION_PLUGIN_VERSION);
 		plugin  = this;
 	}
 

--- a/org.jboss.tools.maven.polyglot.poc.ui/src/main/java/org/jboss/tools/maven/polyglot/poc/internal/ui/preferences/MavenPolyglotPreferencePage.java
+++ b/org.jboss.tools.maven.polyglot.poc.ui/src/main/java/org/jboss/tools/maven/polyglot/poc/internal/ui/preferences/MavenPolyglotPreferencePage.java
@@ -12,6 +12,7 @@ package org.jboss.tools.maven.polyglot.poc.internal.ui.preferences;
 
 import org.eclipse.jface.preference.BooleanFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.jface.preference.StringFieldEditor;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 import org.jboss.tools.maven.polyglot.poc.internal.core.preferences.IPolyglotPreferenceConstants;
@@ -34,7 +35,10 @@ public class MavenPolyglotPreferencePage extends FieldEditorPreferencePage imple
 	    addField(new BooleanFieldEditor(IPolyglotPreferenceConstants.ENABLE_AUTOMATIC_POM_TRANSLATION, 
 	    		                        "Enable automatic polyglot pom translation. pom.xml will be overwritten!",
 	        getFieldEditorParent()));
-	  }
+		addField(new StringFieldEditor(IPolyglotPreferenceConstants.POLYGLOT_TRANSLATION_PLUGIN_VERSION,
+				"Optional version of the polyglot-translate-plugin",
+				getFieldEditorParent()));
+	}
 
 		@Override
 		public boolean performOk() {

--- a/org.jboss.tools.maven.polyglot.poc.ui/src/main/java/org/jboss/tools/maven/polyglot/poc/internal/ui/translation/PolyglotTranslaterJob.java
+++ b/org.jboss.tools.maven.polyglot.poc.ui/src/main/java/org/jboss/tools/maven/polyglot/poc/internal/ui/translation/PolyglotTranslaterJob.java
@@ -53,8 +53,8 @@ public class PolyglotTranslaterJob extends PomTranslatorJob {
 	private boolean addExtension;
 	private File mvnExtensionsDir;
 
-	public PolyglotTranslaterJob(IMavenProjectFacade facade, Language language, boolean addExtension, File mvnExtensionsDir) {
-		super(Collections.singletonList(facade.getPom()));
+	public PolyglotTranslaterJob(IMavenProjectFacade facade, Language language, boolean addExtension, File mvnExtensionsDir, String translatePluginVersion) {
+		super(Collections.singletonList(facade.getPom()), translatePluginVersion);
 		this.facade = facade;
 		this.language = language;
 		this.addExtension = addExtension;

--- a/org.jboss.tools.maven.polyglot.poc.ui/src/main/java/org/jboss/tools/maven/polyglot/poc/internal/ui/translation/PolyglotTranslaterWizard.java
+++ b/org.jboss.tools.maven.polyglot.poc.ui/src/main/java/org/jboss/tools/maven/polyglot/poc/internal/ui/translation/PolyglotTranslaterWizard.java
@@ -19,6 +19,8 @@ import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.jface.wizard.Wizard;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
+import org.jboss.tools.maven.polyglot.poc.internal.core.preferences.IPolyglotPreferenceConstants;
+import org.jboss.tools.maven.polyglot.poc.internal.ui.PolyglotSupportUIActivator;
 
 /**
  * @author Fred Bricon
@@ -41,6 +43,9 @@ public class PolyglotTranslaterWizard extends Wizard {
 
 	@Override
 	public boolean performFinish() {
+		final String versionOrNull = PolyglotSupportUIActivator.getDefault().getPreferenceStore().getString(IPolyglotPreferenceConstants.POLYGLOT_TRANSLATION_PLUGIN_VERSION);
+	    final String version = versionOrNull == null ? "" : versionOrNull.trim();
+		
 		final Language language = translaterPage.getLanguage();
 		final boolean isAddExtension = translaterPage.isAddExtension();
 		final File mvnExtensionsDir = translaterPage.getMvnExtensionsDir(); 
@@ -49,8 +54,8 @@ public class PolyglotTranslaterWizard extends Wizard {
 				monitor.beginTask("Project Translation", 3);
 				try {
 					// No, this is not how Jobs are supposed to be used
-					IStatus result = new PolyglotTranslaterJob(facade, language, isAddExtension,
-							mvnExtensionsDir).run(monitor);
+					final IStatus result = new PolyglotTranslaterJob(facade, language, isAddExtension, mvnExtensionsDir, version)
+							.run(monitor);
 					if (!result.isOK()) {
 						throw new InvocationTargetException(result.getException());
 					}


### PR DESCRIPTION
Adds an extra preferences field were the user can select the used version of the internally used plugin.

This change was essential for me to test and work with a new and unreleased feature of polyglot-maven. That way, I can set a SNAPSHOT-version from my local repository.